### PR TITLE
fixed multiple tap issue for player turn

### DIFF
--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -122,13 +122,19 @@ class _HomePageState extends State<HomePage> {
       if (ohTurn && displayExOh[index] == '') {
         displayExOh[index] = 'o';
         filledBoxes += 1;
+      ohTurn = !ohTurn;
+      _checkWinner();
+        
+        
       } else if (!ohTurn && displayExOh[index] == ''){
         displayExOh[index] = 'x';
         filledBoxes += 1;
-      }
-
       ohTurn = !ohTurn;
       _checkWinner();
+        
+        
+      }
+
     });
   }
 


### PR DESCRIPTION
If you tab on same grid it just update the ohTurn(i.e _ohTurn = !ohTurn) but does not update on screen but it flip the next player turn, which is because you put the _ohTurn = !ohTurn outside the condition statement. If you just put it inside the condition statement it just works fine.

@ujjwalbe